### PR TITLE
Fix Function _load_textdomain_just_in_time error

### DIFF
--- a/includes/classes/class-columns-link.php
+++ b/includes/classes/class-columns-link.php
@@ -160,6 +160,3 @@ class TINYPRESS_Column_link {
 		return self::$_instance;
 	}
 }
-
-
-TINYPRESS_Column_link::instance();

--- a/includes/classes/class-functions.php
+++ b/includes/classes/class-functions.php
@@ -31,9 +31,21 @@ if ( ! class_exists( 'TINYPRESS_Functions' ) ) {
 		 * TINYPRESS_Functions constructor.
 		 */
 		function __construct() {
-			self::$text_hint   = esc_html__( 'Click to Copy.', 'tinypress' );
-			self::$text_copied = esc_html__( 'Copied.', 'tinypress' );
 			self::$connect_url = TINYPRESS_SERVER . 'tiny-connect/?s_url=' . site_url();
+		}
+
+		public static function get_text_hint() {
+			if ( is_null( self::$text_hint ) ) {
+				self::$text_hint = esc_html__( 'Click to Copy.', 'tinypress' );
+			}
+			return self::$text_hint;
+		}
+
+		public static function get_text_copied() {
+			if ( is_null( self::$text_copied ) ) {
+				self::$text_copied = esc_html__( 'Copied.', 'tinypress' );
+			}
+			return self::$text_copied;
 		}
 
 		public static function is_license_active() {
@@ -57,7 +69,3 @@ if ( ! class_exists( 'TINYPRESS_Functions' ) ) {
 		}
 	}
 }
-
-global $tinypress;
-
-$tinypress = new TINYPRESS_Functions();

--- a/includes/classes/class-hooks.php
+++ b/includes/classes/class-hooks.php
@@ -192,5 +192,3 @@ if ( ! class_exists( 'TINYPRESS_Hooks' ) ) {
 		}
 	}
 }
-
-TINYPRESS_Hooks::instance();

--- a/includes/classes/class-meta-boxes.php
+++ b/includes/classes/class-meta-boxes.php
@@ -23,6 +23,15 @@ if ( ! class_exists( 'TINYPRESS_Meta_boxes' ) ) {
 		 * TINYPRESS_Meta_boxes constructor.
 		 */
 		function __construct() {
+			add_action( 'init', array( $this, 'init_meta_boxes' ) );
+			add_action( 'add_meta_boxes', array( $this, 'add_side_meta_box' ), 0 );
+			add_action( 'WPDK_Settings/meta_section/analytics', array( $this, 'render_analytics' ) );
+		}
+
+		/**
+		 * Initialize meta boxes on init to ensure text domain is loaded
+		 */
+		function init_meta_boxes() {
 			$this->tinypress_default_slug = tinypress_create_url_slug();
 
 			$this->generate_tinypress_meta_box();
@@ -32,9 +41,6 @@ if ( ! class_exists( 'TINYPRESS_Meta_boxes' ) ) {
 					$this->generate_tinypress_meta_box_side( $post_type );
 				}
 			}
-
-			add_action( 'add_meta_boxes', array( $this, 'add_side_meta_box' ), 0 );
-			add_action( 'WPDK_Settings/meta_section/analytics', array( $this, 'render_analytics' ) );
 		}
 
 
@@ -293,5 +299,3 @@ if ( ! class_exists( 'TINYPRESS_Meta_boxes' ) ) {
 		}
 	}
 }
-
-tinypress()->tinypress_metaboxes = new TINYPRESS_Meta_boxes();

--- a/includes/classes/class-redirection.php
+++ b/includes/classes/class-redirection.php
@@ -267,5 +267,3 @@ if ( ! class_exists( 'TINYPRESS_Redirection' ) ) {
 		}
 	}
 }
-
-TINYPRESS_Redirection::instance();

--- a/includes/classes/class-settings.php
+++ b/includes/classes/class-settings.php
@@ -18,6 +18,13 @@ if ( ! class_exists( 'TINYPRESS_Settings' ) ) {
 		 * TINYPRESS_Settings constructor.
 		 */
 		public function __construct() {
+			add_action( 'init', array( $this, 'create_settings_page' ) );
+		}
+
+		/**
+		 * Create settings page on init to ensure text domain is loaded
+		 */
+		public function create_settings_page() {
 			global $tinypress_wpdk;
 
 			// Generate settings page
@@ -246,4 +253,3 @@ if ( ! class_exists( 'TINYPRESS_Settings' ) ) {
 		}
 	}
 }
-TINYPRESS_Settings::instance();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -117,7 +117,7 @@ if ( ! function_exists( 'tinypress_get_tiny_slug_copier' ) ) {
 
 		echo '<div class="tiny-slug-wrap ' . esc_attr( $wrapper_class ) . '">';
 
-		echo '<div class="tiny-slug-preview hint--top" aria-label="' . tinypress()::$text_hint . '" data-text-copied="' . tinypress()::$text_copied . '">';
+		echo '<div class="tiny-slug-preview hint--top" aria-label="' . tinypress()::get_text_hint() . '" data-text-copied="' . tinypress()::get_text_copied() . '">';
 
 		if ( $preview ) {
 			echo '<span class="preview"> ' . esc_html__( $preview_text ) . ' </span>';

--- a/includes/wp-dev-kit/settings/classes/setup.class.php
+++ b/includes/wp-dev-kit/settings/classes/setup.class.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'WPDK_Settings' ) ) {
 			do_action( 'pb_settings_init' );
 
 			// Setup textdomain
-			self::textdomain();
+		    add_action( 'init', array( 'WPDK_Settings', 'textdomain' ) );
 
 			add_action( 'after_setup_theme', array( 'WPDK_Settings', 'setup' ) );
 			add_action( 'init', array( 'WPDK_Settings', 'setup' ) );

--- a/tinypress.php
+++ b/tinypress.php
@@ -47,8 +47,8 @@ if ( ! class_exists( 'TINYPRESS_Main' ) ) {
 			$this->define_scripts();
 			$this->define_classes_functions();
 
-			add_action( 'init', array( $this, 'create_data_table' ) );
-			add_action( 'plugins_loaded', array( $this, 'load_text_domain' ) );
+			add_action( 'init', array( $this, 'create_data_table' ), 5 );
+			add_action( 'init', array( $this, 'load_text_domain' ), 0 );
 
 			register_activation_hook( __FILE__, array( $this, 'flush_rewrite_rules' ) );
 		}
@@ -109,6 +109,12 @@ if ( ! class_exists( 'TINYPRESS_Main' ) ) {
 			require_once TINYPRESS_PLUGIN_DIR . 'includes/classes/class-columns-link.php';
 			require_once TINYPRESS_PLUGIN_DIR . 'includes/classes/class-settings.php';
 			require_once TINYPRESS_PLUGIN_DIR . 'includes/classes/class-redirection.php';
+
+			new TINYPRESS_Hooks();
+			new TINYPRESS_Meta_boxes();
+			new TINYPRESS_Column_link();
+			new TINYPRESS_Settings();
+			new TINYPRESS_Redirection();
 		}
 
 


### PR DESCRIPTION
Fix Function _load_textdomain_just_in_time error #10 

- Move text domain loading to 'init' action hook (priority 0) to comply with WordPress 6.7.0 requirements
- Defer WPDK_Settings textdomain() call to 'init' hook in setup.class.php
- Refactor TINYPRESS_Settings to defer settings page creation with translations to 'init' hook
- Refactor TINYPRESS_Meta_boxes to defer meta box initialization with translations to 'init' hook
- Convert TINYPRESS_Functions translation calls to lazy-loaded getter methods (get_text_hint, get_text_copied)
- Update translation function references to use new getter methods in functions.php
- Centralize all class instantiation in tinypress.php define_classes_functions() method
- Ensure proper hook execution order: textdomain (0) → database (5) → classes (10)