### PR TITLE
Fix draft shortlink rendering fallback for Elementor/Hello theme

### DIFF
--- a/includes/classes/class-redirection.php
+++ b/includes/classes/class-redirection.php
@@ -612,11 +612,22 @@ if (! class_exists('TINYPRESS_Redirection')) {
             setup_postdata($post);
             
             status_header(200);
-            $single_template = get_query_template('single');
-            if ($single_template) {
-                include($single_template);
+            $template = get_query_template('single');
+            if (! $template && function_exists('get_single_template')) {
+                $template = get_single_template();
+            }
+
+            if (! $template && function_exists('get_singular_template')) {
+                $template = get_singular_template();
+            }
+
+            if (! $template && function_exists('get_index_template')) {
+                $template = get_index_template();
+            }
+
+            if ($template) {
+                include($template);
             } else {
-                // Fallback: display basic post content if no single template found
                 wp_die(esc_html($post->post_title), esc_html($post->post_title), array( 'response' => 200 ));
             }
         }


### PR DESCRIPTION
Add a safer template fallback chain before falling back to wp_die()

<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Shortlinks plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
Add a safer template fallback chain before falling back to wp_die()

## Benefits
fix #218 

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
#218 
## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
