### PR TITLE
Prevent auto-drafts from creating shortlink entries

### DIFF
--- a/includes/classes/class-autolist.php
+++ b/includes/classes/class-autolist.php
@@ -277,6 +277,10 @@ if (! class_exists('TINYPRESS_AutoList')) {
                 return;
             }
 
+            if ($post->post_status === 'auto-draft') {
+                return;
+            }
+
             $behavior = $this->get_post_type_behavior($post->post_type);
 
             if (! in_array($behavior, array( 'on_create', 'on_first_use_or_on_create' ))) {


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request.

  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

  Please, review the guidelines for contributing to this repository:

  https://github.com/publishpress/PublishPress-Future/blob/development/CONTRIBUTING.md
 -->

## Description
Added an early return for posts with 'auto-draft' status.

The wp_insert_post hook in tinypress_handle_post_created() was firing
whenever WordPress created an auto-draft (e.g., clicking "Add New").
This caused unwanted shortlink entries to pile up on the All Shortlinks
page. 

## Benefits
fix #335 

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
#335 
## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch.
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [ ] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
